### PR TITLE
Movable fix

### DIFF
--- a/src/components/TheChessboard.vue
+++ b/src/components/TheChessboard.vue
@@ -86,6 +86,8 @@ onMounted(() => {
     boardState.value.boardConfig.movable = {
       color: props.playerColor || boardState.value.boardConfig.turnColor,
       dests: possibleMoves(game),
+      free:
+        props.boardConfig?.movable?.free || defaultBoardConfig?.movable?.free,
     };
   }
   board = Chessground(boardElement.value, boardState.value.boardConfig);
@@ -141,6 +143,8 @@ function changeTurn(): (orig: Key, dest: Key) => Promise<void> {
       movable: {
         color: props.playerColor || board.state.turnColor,
         dests: possibleMoves(game),
+        free: 
+          props.boardConfig?.movable?.free || defaultBoardConfig?.movable?.free,
       },
     });
 

--- a/src/components/TheChessboard.vue
+++ b/src/components/TheChessboard.vue
@@ -74,6 +74,8 @@ onMounted(() => {
     boardState.value.boardConfig.movable = {
       color: props.playerColor,
       dests: possibleMoves(game),
+      free:
+        props.boardConfig?.movable?.free || defaultBoardConfig?.movable?.free,
     };
   }
 


### PR DESCRIPTION
Fixes #180 I think.

For some reason, when the playerColor prop is passed into the component, it seemed that the `movable.free` property was set to true. the overwrite `props.boardConfig?.movable?.free || defaultBoardConfig?.movable?.free,` in the `onMounted()` method seemed to fix this issue, and just to be safe I put it in any other `boardConfig` assignments. 

Please take a look at let me know if this solution is any good. 