### PR TITLE
Added game history viewer feature

### DIFF
--- a/docs/HistoryViewerExample.vue
+++ b/docs/HistoryViewerExample.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { TheChessboard, type BoardApi } from '../dist/vue3-chessboard';
+
+let boardAPI: BoardApi | undefined;
+
+</script>
+
+<template>
+  <section class="sect">
+    <button class="button" @click="boardAPI?.viewStart">Start</button>
+    <button class="button" @click="boardAPI?.viewPrevious">Previous</button>
+    <button class="button" @click="boardAPI?.viewNext">Next</button>
+    <button class="button" @click="boardAPI?.stopViewingHistory">End</button>
+  </section>
+  <TheChessboard @board-created="(api) => (boardAPI = api)" />
+</template>
+
+<style scoped>
+.sect {
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 3%;
+}
+.button {
+  border-radius: 4px;
+  padding: 0 12px;
+  letter-spacing: 0.8px;
+  line-height: 36px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid #333;
+  transition: background-color 0.25s;
+  cursor: pointer;
+}
+.dark .button {
+  border: 1px solid #fff;
+}
+</style>

--- a/docs/board-api.md
+++ b/docs/board-api.md
@@ -1,5 +1,6 @@
 <script setup>
 import ChessboardExample from './ChessboardExample.vue';
+import HistoryViewerExample from './HistoryViewerExample.vue';
 </script>
 
 # Board API
@@ -132,9 +133,16 @@ getPossibleMoves(): Map<Key, Key[]> | undefined;
 getCurrentTurnNumber(): number;
 
 /**
+ *
+ * @returns the current ply number
+ * @example e4 e5 Nf3 -> ply number is 3
+ */
+getCurrentPlyNumber(): number;
+
+/**
  * returns the latest move made on the board
  */
-getLastMove(): Move | undefined;
+getLastMove(): MoveEvent | undefined;
 
 /**
  * Retrieves the move history.
@@ -142,7 +150,7 @@ getLastMove(): Move | undefined;
  * @param verbose - passing true will add more info
  * @example Verbose: [{"color": "w", "from": "e2", "to": "e4", "flags": "b", "piece": "p", "san": "e4"}],  without verbose flag: [ "e7", "e5" ]
  */
-getHistory(verbose?: boolean): Move[] | string[];
+getHistory(verbose?: boolean): MoveEvent[] | string[];
 
 /**
  * Returns the FEN string for the current position.
@@ -174,6 +182,11 @@ getIsGameOver(): boolean;
 getIsCheckmate(): boolean;
 
 /**
+ * returns true or false depending on if a player is in check
+ */
+getIsCheck(): boolean;
+
+/**
  * returns true or false depending on if a player is in stalemate
  */
 getIsStalemate(): boolean;
@@ -196,7 +209,7 @@ getIsInsufficientMaterial(): boolean;
 /**
  * returns the color of a given square
  */
-getSquareColor(square: string): SquareColor | null;
+getSquareColor(square: Square): SquareColor;
 
 /**
  * Returns the piece on the square or null if there is no piece
@@ -261,9 +274,47 @@ getPgnInfo(): {
  * @param fillDefaults - if true unprovided config options will be substituted with default values, if
  * false the unprovided options will remain unchanged.
  */
-setConfig(config: BoardConfig, fillDefaults = false): void {
+setConfig(config: BoardConfig, fillDefaults = false): void;
+
+/**
+ * Views the position at the given ply number in the game's history.
+ *
+ * @param ply - the ply number of the position to be viewed, where 0 is the initial position, 1 is
+ * after white's first move, 2 is after black's first move and so on.
+ */
+viewHistory(ply: number): void;
+
+/**
+ * Stops viewing history and returns the board to the present position, ie. after the latest move.
+ */
+stopViewingHistory(): void;
+
+/**
+ * Views the starting position of this game.
+ */
+viewStart(): void;
+
+/**
+ * If viewing history, views the move after the one currently being viewed.
+ * If that move is the latest move, stops viewing history.
+ */
+viewNext(): void;
+
+/**
+ * If viewing history, views the previous move to the one currently being viewed.
+ * Else, starts viewing history and views the move previous to the latest move.
+ */
+viewPrevious(): void;
+
 ```
 
 ## Example Board API Usage
 
 <ChessboardExample />
+
+
+## Example Game History Viewer Usage
+
+<HistoryViewerExample />
+
+When viewing game history, the `viewingHistory` class is applied to the `main-wrap` element. This allows custom styles to be applied to the board only when viewing the history (by default, the board is desaturated).

--- a/src/assets/board.css
+++ b/src/assets/board.css
@@ -345,6 +345,11 @@ cg-board .king.black {
   pointer-events: none;
 }
 
+.viewingHistory {
+  filter: saturate(60%);
+  transition: 0.25s filter linear;
+}
+
 .promotion-dialog {
   padding: 0.4rem 0.8rem 0.8rem 0.8rem;
   position: relative;

--- a/src/classes/BoardApi.ts
+++ b/src/classes/BoardApi.ts
@@ -438,6 +438,9 @@ export class BoardApi {
     return this.game.isCheckmate();
   }
 
+  /**
+   * returns true or false depending on if a player is in check
+   */
   getIsCheck(): boolean {
     return this.game.isCheck();
   }

--- a/src/components/TheChessboard.vue
+++ b/src/components/TheChessboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, reactive, watch, type Ref } from 'vue';
+import { ref, onMounted, reactive, watch } from 'vue';
 import PromotionDialog from './PromotionDialog.vue';
 import { BoardApi } from '@/classes/BoardApi';
 import type { BoardState, Props, Emits } from '@/typings/Chessboard';
@@ -28,10 +28,10 @@ onMounted(() => {
   emit('boardCreated', boardAPI);
 
   if (props.reactiveConfig) {
-    const oldConfig: Ref<BoardConfig> = ref(deepCopy(props.boardConfig));
+    let oldConfig: BoardConfig = deepCopy(props.boardConfig);
     watch(reactive(props.boardConfig), (newConfig: BoardConfig) => {
-      boardAPI.setConfig(deepDiffConfig(oldConfig.value, newConfig));
-      oldConfig.value = deepCopy(newConfig);
+      boardAPI.setConfig(deepDiffConfig(oldConfig, newConfig));
+      oldConfig = deepCopy(newConfig);
     });
   }
 });

--- a/src/components/TheChessboard.vue
+++ b/src/components/TheChessboard.vue
@@ -16,6 +16,7 @@ const boardElement = ref<HTMLElement | null>(null);
 const boardState: BoardState = reactive({
   showThreats: false,
   promotionDialogState: { isEnabled: false },
+  historyViewerState: { isEnabled: false },
 });
 
 onMounted(() => {
@@ -39,7 +40,10 @@ onMounted(() => {
 <template>
   <section
     class="main-wrap"
-    :class="{ disabledBoard: boardState.promotionDialogState.isEnabled }"
+    :class="{
+      disabledBoard: boardState.promotionDialogState.isEnabled,
+      viewingHistory: boardState.historyViewerState.isEnabled,
+    }"
   >
     <div class="main-board">
       <div class="dialog-container">

--- a/src/tests/BoardApi.test.ts
+++ b/src/tests/BoardApi.test.ts
@@ -278,6 +278,103 @@ describe.concurrent('Test the board API', () => {
     expect((boardApi as any).board.state.drawable.enabled).toBe(true);
     expect((boardApi as any).board.state.drawable.visible).toBe(false);
   });
+
+  /**  
+   * History Viewer Tests:
+   */
+  it('views game history', () => {
+    expect((boardApi as any).boardState.historyViewerState.isEnabled).toBe(false);
+    boardApi.move('e4');
+    boardApi.move('e5');
+    boardApi.move('d4');
+    boardApi.move('exd4');
+    expect((boardApi as any).boardState.historyViewerState.isEnabled).toBe(false);
+    boardApi.viewHistory(1);
+    expect((boardApi as any).boardState.historyViewerState.isEnabled).toBe(true);
+    expect((boardApi as any).boardState.historyViewerState.plyViewing).toBe(1);
+    expect((boardApi as any).board.state.fen).toBe('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1');    
+  });
+  
+  it('views the previous move when not viewing history', () => {
+    boardApi.move('e4');
+    boardApi.move('e5');
+    boardApi.viewPrevious();
+    expect((boardApi as any).boardState.historyViewerState.isEnabled).toBe(true);
+    expect((boardApi as any).boardState.historyViewerState.plyViewing).toBe(1);
+    expect((boardApi as any).board.state.fen).toBe('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1');
+  });
+  
+  it('views the previous move when already viewing history', () => {
+    boardApi.move('e4');
+    boardApi.move('e5');
+    boardApi.viewPrevious();
+    boardApi.viewPrevious();
+    expect((boardApi as any).boardState.historyViewerState.isEnabled).toBe(true);
+    expect((boardApi as any).boardState.historyViewerState.plyViewing).toBe(0);
+    expect((boardApi as any).board.state.fen).toBe('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1');
+  });
+  
+  it('views the next move when viewing history', () => {
+    boardApi.move('e4');
+    boardApi.move('e5');
+    boardApi.viewHistory(0);
+    boardApi.viewNext();
+    expect((boardApi as any).boardState.historyViewerState.isEnabled).toBe(true);
+    expect((boardApi as any).boardState.historyViewerState.plyViewing).toBe(1);
+    expect((boardApi as any).board.state.fen).toBe('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1');
+  });
+  
+  it('views the first turn', () => {
+    boardApi.move('e4');
+    boardApi.move('e5');
+    boardApi.viewStart();
+    expect((boardApi as any).boardState.historyViewerState.isEnabled).toBe(true);
+    expect((boardApi as any).boardState.historyViewerState.plyViewing).toBe(0);
+    expect((boardApi as any).board.state.fen).toBe('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1');
+  });
+  
+  it('stops viewing history', () => {
+    boardApi.move('e4');
+    boardApi.viewHistory(0);
+    boardApi.stopViewingHistory();
+    expect((boardApi as any).boardState.historyViewerState.isEnabled).toBe(false);
+    expect((boardApi as any).board.state.fen).toBe('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1');
+  });
+  
+  it('enableds viewOnly when viewing history', () => {
+    expect((boardApi as any).board.state.viewOnly).toBe(false);
+    boardApi.move('e4');
+    boardApi.viewHistory(0);
+    expect((boardApi as any).board.state.viewOnly).toBe(true);
+  });
+  
+  it('disableds viewOnly when stopping viewing history if it should be disabled', () => {
+    expect((boardApi as any).board.state.viewOnly).toBe(false);
+    boardApi.move('e4');
+    boardApi.viewHistory(0);
+    boardApi.stopViewingHistory();
+    expect((boardApi as any).board.state.viewOnly).toBe(false);
+  });
+  
+  it('keeps viewOnly enabled when stopping viewing history if it should be enabled', () => {
+    boardApi.setConfig({ viewOnly: true })
+    expect((boardApi as any).board.state.viewOnly).toBe(true);
+    boardApi.move('e4');
+    boardApi.viewHistory(0);
+    boardApi.stopViewingHistory();
+    expect((boardApi as any).board.state.viewOnly).toBe(true);
+  });
+    
+  it('keeps animation enabled if it should be enabled', () => {
+    expect((boardApi as any).board.state.animation.enabled).toBe(true);
+    boardApi.move('e4');
+    boardApi.move('e5');
+    boardApi.viewStart();
+    expect((boardApi as any).board.state.animation.enabled).toBe(true);
+    boardApi.stopViewingHistory();
+    expect((boardApi as any).board.state.animation.enabled).toBe(true);
+  });
+  
 });
 
 export {};

--- a/src/typings/Chessboard.ts
+++ b/src/typings/Chessboard.ts
@@ -94,4 +94,5 @@ export type HistoryViewerState =
   | {
       isEnabled: true;
       plyViewing: number;
+      viewOnly: boolean;
     };

--- a/src/typings/Chessboard.ts
+++ b/src/typings/Chessboard.ts
@@ -68,6 +68,7 @@ export interface Props {
 export interface BoardState {
   showThreats: boolean;
   promotionDialogState: PromotionDialogState;
+  historyViewerState: HistoryViewerState;
 }
 
 export interface PromotionDialogState {
@@ -85,3 +86,12 @@ export interface PromotionEvent {
 export type PromotedTo = PromotionEvent['promotedTo'];
 
 export type MoveEvent = FullMove;
+
+export type HistoryViewerState =
+  | {
+      isEnabled: false;
+    }
+  | {
+      isEnabled: true;
+      plyViewing: number;
+    };


### PR DESCRIPTION
 - Added game history viewer feature and several associated methods:
   - `viewHistory` to view the position at a specific ply
   - `stopViewingHistory` to return to the present position
   - `viewStart` to view the starting position
   - `viewNext` to view the next move when viewing history
   - `viewPrevious` to view the previous move
 - Some miscellaneous fixes
 -  Updated docs
 - Added tests