### PR TITLE
feat: add support for setting pgn headers

### DIFF
--- a/src/classes/BoardApi.ts
+++ b/src/classes/BoardApi.ts
@@ -591,6 +591,21 @@ export class BoardApi {
   }
 
   /**
+   * Sets a header in the PGN.
+   *
+   * @param key the key to change, e.g. "Event"
+   * @param value the value to set, e.g. "IBM Kasparov vs. Deep Blue Rematch"
+   */
+  setPgnInfo(
+    key: string,
+    value: string
+  ): {
+    [key: string]: string | undefined;
+  } {
+    return this.game.header(key, value);
+  }
+
+  /**
    * Sets the config of the board.
    * Caution: providing a config with a fen will erase the game history and change the starting position
    * for resetBoard. To keep history and starting position: omit fen from the given config and call

--- a/src/classes/BoardApi.ts
+++ b/src/classes/BoardApi.ts
@@ -593,16 +593,12 @@ export class BoardApi {
   /**
    * Sets a header in the PGN.
    *
-   * @param key the key to change, e.g. "Event"
-   * @param value the value to set, e.g. "IBM Kasparov vs. Deep Blue Rematch"
+   * @param changes a record of key value pairs to change in the PGN, eg. `{ White: 'Deep Blue', Black: 'Kasparov, Garry' }`
    */
-  setPgnInfo(
-    key: string,
-    value: string
-  ): {
+  setPgnInfo(changes: { [key: string]: string }): {
     [key: string]: string | undefined;
   } {
-    return this.game.header(key, value);
+    return this.game.header(...Object.entries(changes).flat());
   }
 
   /**

--- a/src/tests/BoardApi.test.ts
+++ b/src/tests/BoardApi.test.ts
@@ -433,6 +433,11 @@ describe.concurrent('Test the board API', () => {
     boardApi.stopViewingHistory();
     expect((boardApi as any).board.state.animation.enabled).toBe(true);
   });
+
+  it('adds a pgn header and checks if it is added', () => {
+    boardApi.setPgnInfo('White', 'Test');
+    expect(boardApi.getPgn()).toContain('[White "Test"]');
+  });
 });
 
 export {};

--- a/src/tests/BoardApi.test.ts
+++ b/src/tests/BoardApi.test.ts
@@ -435,8 +435,10 @@ describe.concurrent('Test the board API', () => {
   });
 
   it('adds a pgn header and checks if it is added', () => {
-    boardApi.setPgnInfo('White', 'Test');
-    expect(boardApi.getPgn()).toContain('[White "Test"]');
+    boardApi.setPgnInfo({ White: "Deep Blue", Black: "Kasparov", Date: "1997.05.11" });
+    expect(boardApi.getPgn()).toContain('[White "Deep Blue"]');
+    expect(boardApi.getPgn()).toContain('[Black "Kasparov"]');
+    expect(boardApi.getPgn()).toContain('[Date "1997.05.11"]');
   });
 });
 


### PR DESCRIPTION
Hi there :)

Using this in my [own project](https://github.com/Chew/ChessTools) and wanted a way to set PGN headers. If this already exists some other way, please let me know!

Even added a test for it as well. Nifty little test suite there.