### PR TITLE
Fix wrong piece size

### DIFF
--- a/src/components/TheChessboard.vue
+++ b/src/components/TheChessboard.vue
@@ -164,8 +164,8 @@ cg-board piece {
   position: absolute;
   top: 0;
   left: 0;
-  width: 12%;
-  height: 12%;
+  width: 12.5%;
+  height: 12.5%;
   background-size: cover;
   z-index: 2;
   will-change: transform;


### PR DESCRIPTION
Before this PR pieces had the wrong size, leading to them being off-centre in their respective square.
This behaviour is also visible in the [documentation](https://qwerty084.github.io/vue3-chessboard-docs/getting-started.html).

This PR fixes this issue.

Before: 
![image](https://github.com/qwerty084/vue3-chessboard/assets/12512150/aa26278d-758f-4849-9735-4b50b3ee69ae)

After: 
![image](https://github.com/qwerty084/vue3-chessboard/assets/12512150/1ecfec88-a5df-42ad-96ae-fa2982644155)

Credits to @stefnotch for finding the cause of this issue.