### PR TITLE
Don't hardcode size and layout of board component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@ const playerColor: 'white' | 'black' | 'both' | undefined = undefined;
   <TheChessboard
     :board-config="boardConfig"
     :player-color="playerColor"
+    class="board"
     @board-created="(api) => (boardAPI = api)"
   />
 </template>
@@ -21,5 +22,12 @@ const playerColor: 'white' | 'black' | 'both' | undefined = undefined;
 <style>
 body {
   background-color: #222;
+}
+@media (orientation: landscape) {
+  .board {
+    width: 90vh;
+    margin-inline: auto;
+    max-width: 700px;
+  }
 }
 </style>

--- a/src/components/TheChessboard.vue
+++ b/src/components/TheChessboard.vue
@@ -60,8 +60,9 @@ onMounted(() => {
 
 <style>
 .cg-wrap {
-  width: 700px;
-  height: 700px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .main-board {
@@ -201,8 +202,6 @@ cg-container {
   width: 100%;
   height: 100%;
   display: block;
-  top: 0;
-  right: 0;
 }
 
 cg-board {
@@ -416,13 +415,5 @@ cg-board .king.black {
 .viewingHistory {
   filter: saturate(60%);
   transition: 0.25s filter linear;
-}
-
-@media (orientation: landscape) {
-  .main-wrap {
-    width: 90vh;
-    margin-inline: auto;
-    max-width: 700px;
-  }
 }
 </style>


### PR DESCRIPTION
This PR aims to make the component more flexible and easier to integrate into any website layout. 

Currently, the size and layout of the board component are hardcoded and can only be changed by overriding the component's CSS. 

What is currently hardcoded in the component:
- size of 700x700: `.cg-wrap { width: 700px; height: 700px; }`
- in landscape mode: the board may take 90% of the verticle size of the viewport: `width: 90vh;`
- in landscape mode: the board is horizontally centred in the parent HTML element:  `margin-inline: auto;`

Since the size of the `cg-container` is enforced by the [chess-ground library](https://github.com/lichess-org/lila/issues/5184) to be a multiple of 8, it is possible that the wrapper div `cg-wrap` is bigger by at most 7px in both dimensions. This gap used to be only on the left and bottom but in my opinion, it looks better when it is evenly distributed on all 4 sides. That's why I changed the `cg-wrap`'s display to `flex` and centred its contents. Let me know if you think this can lead to some issues. 

The suggested changes require the user to provide reasonable definitions for the size of the component (there is no default size).
If no user-supplied CSS is provided, it tries to take up as much of the width as possible, while potentially cutting off parts of the bottom half of the board if the page is in landscape mode. See:
![image](https://github.com/qwerty084/vue3-chessboard/assets/12512150/41cc9c91-93e7-489b-b18a-a03e9fd4396a)

This is probably a breaking change, in the sense that, updating might change the looks of the website.

Let me know what you think! I'm sure we can work out a solution.