### PR TITLE
Add PGN comments support

### DIFF
--- a/src/classes/BoardApi.ts
+++ b/src/classes/BoardApi.ts
@@ -624,6 +624,35 @@ export class BoardApi {
   }
 
   /**
+   * returns the comment for the current position, if it exists.
+   */
+  getPgnComment(): string {
+    // this.game.getComment() is not compatible with history
+    // Iterate over all comments and compare the board FEN instead
+    for (let comment of this.game.getComments()) {
+      if (comment.fen.startsWith(this.board.getFen())) {
+        return comment.comment;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * returns the comments for all positions.
+   */
+  getPgnComments(): [{fen: string, comment: string}] {
+    return this.game.getComments();
+  }
+
+  /**
+   * Comment on the current position. Does not work with history.
+   * @param comment the comment to add to the current position
+   */
+  setPgnComment(comment: string) {
+    this.game.setComment(comment);
+  }
+
+  /**
    * Sets the config of the board.
    * Caution: providing a config with a fen will erase the game history and change the starting position
    * for resetBoard. To keep history and starting position: omit fen from the given config and call

--- a/src/tests/BoardApi.test.ts
+++ b/src/tests/BoardApi.test.ts
@@ -444,6 +444,20 @@ describe.concurrent('Test the board API', () => {
     expect(boardApi.getPgn()).toContain('[Black "Kasparov"]');
     expect(boardApi.getPgn()).toContain('[Date "1997.05.11"]');
   });
+
+  it('load a pgn and check if the comments are returned', () => {
+    boardApi.loadPgn('1. e4 {first move} e5 2. Nf3 Nc6 3. Bc4 Bc5 {giuoco piano} *');
+    expect(boardApi.getPgnComments().map(x => x.comment)).toContain('giuoco piano');
+    boardApi.viewHistory(1);
+    expect(boardApi.getPgnComment()).toEqual('first move');
+    boardApi.viewHistory(6);
+    expect(boardApi.getPgnComment()).toEqual('giuoco piano');
+  });
+
+  it('set a pgn comment and check if it is returned', () => {
+    boardApi.setPgnComment('test');
+    expect(boardApi.getPgnComment()).toEqual('test');
+  });
 });
 
 export {};


### PR DESCRIPTION
Use chess.js to parse PGN comments. The get functions are compatible with history.